### PR TITLE
Add valid fields to SENSOR_AIRFLOW_ANGLES

### DIFF
--- a/message_definitions/v1.0/ASLUAV.xml
+++ b/message_definitions/v1.0/ASLUAV.xml
@@ -285,7 +285,9 @@
       <description>Calibrated airflow angle measurements</description>
       <field type="uint64_t" name="timestamp" units="us">Timestamp</field>
       <field type="float" name="angleofattack" units="deg">Angle of attack</field>
+      <field type="uint8_t" name="angleofattack_valid">Angle of attack measurement valid</field>
       <field type="float" name="sideslip" units="deg">Sideslip angle</field>
+      <field type="uint8_t" name="sideslip_valid">Sideslip angle measurement valid</field>
     </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
Those fields indicate if the measurements are valid (e.g. in the calibrated range of the sensor).